### PR TITLE
Add header support for custom methods DEV-4751

### DIFF
--- a/lib/active_resource/custom_methods.rb
+++ b/lib/active_resource/custom_methods.rb
@@ -53,28 +53,33 @@ module ActiveResource
         # <tt>:from</tt> option. For example:
         #
         #   Person.find(:all, :from => :active)
-        def get(custom_method_name, options = {})
-          hashified = format.decode(connection.get(custom_method_collection_url(custom_method_name, options), headers).body)
+        def get(custom_method_name, options = {}, header_params = headers)
+          custom_headers = headers.merge(header_params || {})
+          hashified = format.decode(connection.get(custom_method_collection_url(custom_method_name, options), custom_headers).body)
           derooted  = Formats.remove_root(hashified)
           derooted.is_a?(Array) ? derooted.map { |e| Formats.remove_root(e) } : derooted
         end
 
-        def post(custom_method_name, options = {}, body = '')
-          connection.post(custom_method_collection_url(custom_method_name, options), body, headers)
+        def post(custom_method_name, options = {}, body = '', header_params = headers)
+          custom_headers = headers.merge(header_params || {})
+          connection.post(custom_method_collection_url(custom_method_name, options), body, custom_headers)
         end
 
-        def patch(custom_method_name, options = {}, body = '')
-          connection.patch(custom_method_collection_url(custom_method_name, options), body, headers)
+        def patch(custom_method_name, options = {}, body = '', header_params = headers)
+          custom_headers = headers.merge(header_params || {})
+          connection.patch(custom_method_collection_url(custom_method_name, options), body, custom_headers)
         end
 
-        def put(custom_method_name, options = {}, body = '')
-          connection.put(custom_method_collection_url(custom_method_name, options), body, headers)
+        def put(custom_method_name, options = {}, body = '', header_params = headers)
+          custom_headers = headers.merge(header_params || {})
+          connection.put(custom_method_collection_url(custom_method_name, options), body, custom_headers)
         end
 
-        def delete(custom_method_name, options = {})
+        def delete(custom_method_name, options = {}, header_params = headers)
+          custom_headers = headers.merge(header_params || {})
           # Need to jump through some hoops to retain the original class 'delete' method
           if custom_method_name.is_a?(Symbol)
-            connection.delete(custom_method_collection_url(custom_method_name, options), headers)
+            connection.delete(custom_method_collection_url(custom_method_name, options), custom_headers)
           else
             orig_delete(custom_method_name, options)
           end


### PR DESCRIPTION
https://bypassmobile.atlassian.net/browse/DEV-4751

Add the ability to send our custom headers through the custom methods via ActiveResource.  This allows us to use #get to grab data from the monolith and not magically instantiate objects so we can treat data as hashes.  You'll see an example in a subsequent refactor PR for standsheets-service
1. The notable change to see is that each method now takes an additional header parameter, which if isn't provided will still use the configured header for the base class.
2. custom_headers is where I just merge the pre-existing header defined on the class with the passed in headers to create one hash of headers which I then pass along to the connection.get
